### PR TITLE
Add code for closing banner permanently

### DIFF
--- a/inc/config.sample.inc.php
+++ b/inc/config.sample.inc.php
@@ -141,6 +141,7 @@ $wbRipCache = null;
 $wbImageCache = null;
 $wbPageCacheList = null;
 $wbImageCacheList = null;
+$wbBannerWasClosedCookie = "centralnotice_wmde15_hide_cookie";
 
 if ( defined('SETUP_WIKI_BOXES') && isset($wbWikiUrl) ) {
 	debug(__FILE__, "setting up wiki boxes", $wbWikiUrl);
@@ -181,6 +182,7 @@ if ( defined('SETUP_WIKI_BOXES') && isset($wbWikiUrl) ) {
       $featurebox->cache_duration = $wbCacheDuration;
       $featurebox->page_cache_list = $wbPageCacheList;
       $featurebox->image_cache_list = $wbImageCacheList;
+	  $featurebox->bannerWasClosedCookieName = $wbBannerWasClosedCookie;
 
       $bannerbox = new WikiBox( $wbWikiUrl, $wbRipCache, null, new CookieJar( $cookieJarParams ) );
       $bannerbox->setImageCache($wbImageCache, $wbImageCachePath, $wbImageCacheExceptions);
@@ -188,6 +190,7 @@ if ( defined('SETUP_WIKI_BOXES') && isset($wbWikiUrl) ) {
       $bannerbox->cache_duration = $wbCacheDuration;
       $bannerbox->page_cache_list = $wbPageCacheList;
       $bannerbox->image_cache_list = $wbImageCacheList;
+	  $bannerbox->bannerWasClosedCookieName = $wbBannerWasClosedCookie;
 }
 
 $featuretest = @$_GET['featuretest'];

--- a/inc/config.sample.inc.php
+++ b/inc/config.sample.inc.php
@@ -45,11 +45,11 @@ $blockedSearches = array();
 
 if ( empty($myDomain) ) {
 	if ( !empty($_SERVER['HTTP_HOST'] ) ) {
-        	$myDomain = $_SERVER['HTTP_HOST'];
+			$myDomain = $_SERVER['HTTP_HOST'];
 	} else if ( !empty($_SERVER['SERVER_NAME']) ) {
-        	$myDomain = $_SERVER['SERVER_NAME'];
+			$myDomain = $_SERVER['SERVER_NAME'];
 	} else {
-        	$myDomain = false;
+			$myDomain = false;
 	}
 }
 
@@ -68,12 +68,12 @@ if ( $cliMode && !empty( $argv[1] ) && $argv[1] == 'debug' ) {
 }
 
 if ( $devMode ) {
-        error_reporting( E_ALL );
-        ini_set( "display_errors", 1 );
+		error_reporting( E_ALL );
+		ini_set( "display_errors", 1 );
 }
 
 if ( $devMode && $cliMode ) { // dev mode, use local resources
-        if ( !function_exists('debug') ) {
+		if ( !function_exists('debug') ) {
 			function debug($location, $msg = "", $var = "nothing9874325") {
 				$s = "";
 				
@@ -85,7 +85,7 @@ if ( $devMode && $cliMode ) { // dev mode, use local resources
 			}
 		}
 
-        if ( !function_exists('backtrace') ) {
+		if ( !function_exists('backtrace') ) {
 			function backtrace($label) {
 				debug_print_backtrace();
 			}
@@ -110,14 +110,14 @@ if ( $devMode ) { // dev mode, use local resources
 		
 		$firephp->registerExceptionHandler(false);
 		
-        if ( !function_exists('debug') ) {
+		if ( !function_exists('debug') ) {
 			function debug($location, $name = "", $var = "") {
 				global $firephp; 
 				$firephp->log($var, $location . ': ' . $name);
 			}
 		}
 
-        if ( !function_exists('backtrace') ) {
+		if ( !function_exists('backtrace') ) {
 			function backtrace($label) {
 				global $firephp; 
 				$firephp->trace($label);
@@ -146,29 +146,29 @@ $wbBannerWasClosedCookie = "centralnotice_wmde15_hide_cookie";
 if ( defined('SETUP_WIKI_BOXES') && isset($wbWikiUrl) ) {
 	debug(__FILE__, "setting up wiki boxes", $wbWikiUrl);
 
-      require_once("wikibox.class.php");
-      
-	  if ( $wbInternalCacheMode ) {
-		  $buff = new LocalCache($wbCachePrefix, $wbInternalCacheMode);
-		  $wbRipCache = new BufferedFileCache($buff, $wbCacheDir, $wbCachePrefix);      
-		  $wbRipCache->buffer_expiry = $wbCacheBufferDuration;
-	  } else if ( $wbMemcachedServer ) {
-		  $buff = new MemcachedCache($wbMemcachedServer, $wbCachePrefix);
-		  $wbRipCache = new BufferedFileCache($buff, $wbCacheDir, $wbCachePrefix);      
-		  $wbRipCache->buffer_expiry = $wbCacheBufferDuration;
-	  } else {
-		  $wbRipCache = new FileCache($wbCacheDir, $wbCachePrefix);      
-	  }
+	require_once("wikibox.class.php");
 
-	  if ( $wbImageCacheDir ) {
-		  $wbImageCache = new FileCache($wbImageCacheDir, $wbCachePrefix);
-		  $wbImageCache->serialize = false; // raw data, not serialized
-		  $wbImageCache->suffix = ""; // keep extension
-		  $wbImageCache->fmode = 0644; //make cached files readable
-	  }
+	if ( $wbInternalCacheMode ) {
+		$buff = new LocalCache($wbCachePrefix, $wbInternalCacheMode);
+		$wbRipCache = new BufferedFileCache($buff, $wbCacheDir, $wbCachePrefix);
+		$wbRipCache->buffer_expiry = $wbCacheBufferDuration;
+	} else if ( $wbMemcachedServer ) {
+		$buff = new MemcachedCache($wbMemcachedServer, $wbCachePrefix);
+		$wbRipCache = new BufferedFileCache($buff, $wbCacheDir, $wbCachePrefix);
+		$wbRipCache->buffer_expiry = $wbCacheBufferDuration;
+	} else {
+		$wbRipCache = new FileCache($wbCacheDir, $wbCachePrefix);
+	}
 
-		$wbPageCacheList = new FreshCacheList( "$wbCacheDir/{$wbCachePrefix}page-cache.list" );
-		$wbImageCacheList = new FreshCacheList( "$wbImageCacheDir/{$wbCachePrefix}image-cache.list" );
+	if ( $wbImageCacheDir ) {
+		$wbImageCache = new FileCache($wbImageCacheDir, $wbCachePrefix);
+		$wbImageCache->serialize = false; // raw data, not serialized
+		$wbImageCache->suffix = ""; // keep extension
+		$wbImageCache->fmode = 0644; //make cached files readable
+	}
+
+	$wbPageCacheList = new FreshCacheList( "$wbCacheDir/{$wbCachePrefix}page-cache.list" );
+	$wbImageCacheList = new FreshCacheList( "$wbImageCacheDir/{$wbCachePrefix}image-cache.list" );
 
 	$cookieJarParams = array(
 			'expire' => time() + 604800, /* 1 week */
@@ -176,21 +176,21 @@ if ( defined('SETUP_WIKI_BOXES') && isset($wbWikiUrl) ) {
 			#'domain' => 'www.wikipedia.de',
 			'path' => '/wpde'
 	);
-      $featurebox = new WikiBox( $wbWikiUrl, $wbRipCache, null, new CookieJar( $cookieJarParams ) );
-      $featurebox->setImageCache($wbImageCache, $wbImageCachePath, $wbImageCacheExceptions);
-      $featurebox->purge = $purge;
-      $featurebox->cache_duration = $wbCacheDuration;
-      $featurebox->page_cache_list = $wbPageCacheList;
-      $featurebox->image_cache_list = $wbImageCacheList;
-	  $featurebox->bannerWasClosedCookieName = $wbBannerWasClosedCookie;
+	$featurebox = new WikiBox( $wbWikiUrl, $wbRipCache, null, new CookieJar( $cookieJarParams ) );
+	$featurebox->setImageCache($wbImageCache, $wbImageCachePath, $wbImageCacheExceptions);
+	$featurebox->purge = $purge;
+	$featurebox->cache_duration = $wbCacheDuration;
+	$featurebox->page_cache_list = $wbPageCacheList;
+	$featurebox->image_cache_list = $wbImageCacheList;
+	$featurebox->bannerWasClosedCookieName = $wbBannerWasClosedCookie;
 
-      $bannerbox = new WikiBox( $wbWikiUrl, $wbRipCache, null, new CookieJar( $cookieJarParams ) );
-      $bannerbox->setImageCache($wbImageCache, $wbImageCachePath, $wbImageCacheExceptions);
-      $bannerbox->purge = $purge;
-      $bannerbox->cache_duration = $wbCacheDuration;
-      $bannerbox->page_cache_list = $wbPageCacheList;
-      $bannerbox->image_cache_list = $wbImageCacheList;
-	  $bannerbox->bannerWasClosedCookieName = $wbBannerWasClosedCookie;
+	$bannerbox = new WikiBox( $wbWikiUrl, $wbRipCache, null, new CookieJar( $cookieJarParams ) );
+	$bannerbox->setImageCache($wbImageCache, $wbImageCachePath, $wbImageCacheExceptions);
+	$bannerbox->purge = $purge;
+	$bannerbox->cache_duration = $wbCacheDuration;
+	$bannerbox->page_cache_list = $wbPageCacheList;
+	$bannerbox->image_cache_list = $wbImageCacheList;
+	$bannerbox->bannerWasClosedCookieName = $wbBannerWasClosedCookie;
 }
 
 $featuretest = @$_GET['featuretest'];

--- a/inc/wikibox.class.php
+++ b/inc/wikibox.class.php
@@ -7,6 +7,7 @@ class WikiBox extends WikiRip {
 
 	private $bannerParameters;
 	private $cookieJar;
+	public $bannerWasClosedCookieName = 'hide_banner';
 
 	function __construct( $url, $cache = null, $cachedir = null, CookieJar $cookieJar = null ) {
 		$this->cookieJar = $cookieJar;
@@ -103,6 +104,10 @@ class WikiBox extends WikiRip {
 
 	private function getPageTitleByParams( $params ) {
 		if ( !array_key_exists( 'title', $params ) ) {
+			return false;
+		}
+
+		if ( $this->cookieJar->getCookie( $this->bannerWasClosedCookieName ) ) {
 			return false;
 		}
 

--- a/tests/phpunit/WikiBoxTest.php
+++ b/tests/phpunit/WikiBoxTest.php
@@ -136,6 +136,33 @@ NOW
 		$wikibox->pick_page( 'Web:Banner' );
 	}
 
+	public function testWhenCloseCookieIsSet_pickPageReturnsFalse() {
+		$cookieJar = $this->getMockBuilder( '\WMDE\wpde\CookieJar' )
+				->disableOriginalConstructor()
+				->setMethods( array( 'getCookie' ) )
+				->getMock();
+
+		$map = array(
+				array( 'impCount', 0 ),
+				array( 'overallImpCount', 0 ),
+				array( 'unittest_hide_cookie', 1 )
+		);
+
+		$cookieJar->expects( $this->any() )
+				->method( 'getCookie' )
+				->will( $this->returnValueMap( $map ) );
+
+		$wikibox = $this->createNewWikiBox( $cookieJar );
+		$wikibox->bannerWasClosedCookieName = 'unittest_hide_cookie';
+
+		$wikibox->expects( $this->once() )
+				->method( 'rip_page' )
+				->with( 'Web:Banner', 'raw' )
+				->willReturn( '* {{BannerDefinition|title=Some_banner|campaign=unittest}}' );
+
+		$this->assertFalse( $wikibox->pick_page( 'Web:Banner' ) );
+	}
+
 	private function createNewWikiBox( $cookieJar = null ) {
 		if ( !$cookieJar ) {
 			$cookieJar = $this->getMockBuilder( '\WMDE\wpde\CookieJar' )


### PR DESCRIPTION
The banner Javascript can set a cookie for closing the banner
permanently. The new code honors that cookie when selecting which
banners can be displayed.

This is a prerequisite for https://github.com/wmde/fundraising/issues/847 and complementary server-side code to make https://github.com/wmde/FundraisingBanners/pull/78 work on wikipedia.de