### PR TITLE
Remove "newest donors" during fundraising

### DIFF
--- a/inc/functions.inc.php
+++ b/inc/functions.inc.php
@@ -58,6 +58,21 @@ function getLatestDonorsString($max=3) {
 	return htmlspecialchars(join(", ",$donors));
 }
 
+/**
+ *  Return if a fundraising campaign is active.
+ *
+ *  At the moment, this is entirely date-based:
+ *  Fundraising season in Germany is in November and December and the 1st week of January
+ *
+ * @return boolean
+ */
+function fundraisingCampaignIsActive() {
+	$now = new DateTime();
+	$month = $now->format( 'n' );
+	$day = $now->format( 'j' );
+	return $month == 11 || $month == 12 || ( $month == 1 && $day < 7 );
+}
+
 function getLatestDonors($max=3, $purge = false) {
 	global $wbRipCache, $wbCacheDuration;
 	

--- a/index.php
+++ b/index.php
@@ -109,7 +109,15 @@ echo '<a href="https://wikipedia.org">mehr</a>';
 		<a onclick="triggerPiwikTrack(this, 'wikimedia.de');" href="http://www.wikimedia.de">Wikimedia Deutschland e.V.</a>
 		&nbsp;&ndash;&nbsp; <a href="./imprint" onclick="triggerPiwikTrack(this, 'impressum');">Impressum&nbsp;und&nbsp;Datenschutz</a>
 	</p>
-	<?php $donors = trim( getLatestDonorsString(3) ); ?>
+	<?php
+		// Deactivate donor names during the fundraising campaign
+		if( fundraisingCampaignIsActive() ) {
+			$donors = false;
+		}
+		else {
+			$donors = trim( getLatestDonorsString(3) );
+		}
+	?>
 	<?php  if ( $donors ) { ?>
 	<p>Wir danken <a onclick="triggerPiwikTrack(this, 'donation-list');" href="https://spenden.wikimedia.de/spenden/list.php">unseren neusten Spendern</a>: <strong> <?= $donors ?></strong></p>
 	<?php } ?>


### PR DESCRIPTION
During the fundraising campaign, no "newest donors" link shall show on
the front page.

This resolves https://github.com/wmde/fundraising/issues/891