### PR TITLE
Add ID to the element containing "Settings" link, and move its styles…

### DIFF
--- a/index.php
+++ b/index.php
@@ -49,7 +49,7 @@ else if ( @$topBanners ) banner($topBanners, "donationbox_top", "Jetzt spenden!"
   <tr>
   <td style="text-align:left; padding:.5em 1em; vertical-align:top;">Die Hauptseite der deutschsprachigen Wikipedia finden Sie unter <a href="https://de.wikipedia.org">https://de.wikipedia.org</a>.</td>
 
-  <td style="padding:.5em 1em; width:8em; text-align:right; vertical-align:top;">
+  <td id="propertiesLink">
     <a href="properties">Einstellungen</a>
   </td>
 

--- a/style.css
+++ b/style.css
@@ -70,6 +70,13 @@ h3 {
 	padding:1em;
 }
 
+#propertiesLink {
+    padding: .5em 1em;
+    width:8em;
+    text-align:right;
+    vertical-align: top;
+}
+
 #main {
 	clear:both;
 	padding-top:2em;


### PR DESCRIPTION
… to the stylesheet

This makes it possible to move "Einstellungen" text left if the sensitive banner's hint is shown (so the hint does not cover the link), as discussed in https://github.com/wmde/fundraising/issues/893