### PR TITLE
T173920 Stop loading deleted resources

### DIFF
--- a/index.php
+++ b/index.php
@@ -32,9 +32,6 @@ $onKeyUp = "triggerSuggestLater('$lang');"
 	<link rel="stylesheet" media="screen" type="text/css" href="style.css" />
 	<script type="text/javascript" src="js/jquery-1.11.3.min.js"></script>
 	<script language="JavaScript" type="text/javascript" src="suggest.js"></script>
-	<script language="JavaScript" type="text/javascript" src="fundraising/banner.js"></script>
-	<script language="JavaScript" type="text/javascript" src="fundraising/banner.config.js"></script>
-	<script language="JavaScript" type="text/javascript" src="fundraising/banner.tracking.js"></script>
 </head>
 
 <body onload="self.focus();document.getElementById('txtSearch').focus();">


### PR DESCRIPTION
Scripts were deleted in 1769a13c3a4a2d7685171706aa873a762caecc76 but still referenced in index.php til this day - causing 404s on prod. Unless there is a big catch, this is probably not the desired behaviour.

Part of the stuff in `fundraising/*` is possibly not needed either (none of it is referenced outside of it), but this is harder to tell.