### PR TITLE
Fix tracking snippet

### DIFF
--- a/tracking.js
+++ b/tracking.js
@@ -1,8 +1,9 @@
+var _paq = _paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push( ['trackPageView'] );
+_paq.push( ['enableLinkTracking'] );
+
 (function() {
-	var _paq = _paq || [];
-	/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-	_paq.push( ['trackPageView'] );
-	_paq.push( ['enableLinkTracking'] );
 	var u = "//stats.wikimedia.de/";
 	_paq.push( ['setTrackerUrl', u + 'piwik.php'] );
 	_paq.push( ['setSiteId', '3'] );


### PR DESCRIPTION
This is for https://phabricator.wikimedia.org/T201324

Explanation:
While putting the tracking code into its own js file, we accidentally
made the global _paq array local to the anonymous closure of the
initialization code, which made it local.

The Matomo code then could not find any information about the tracker
URL and site ID and did not contact the tracker URL. Our tracker
dashboard contained only visits that used the <noscript> fallback.