### PR TITLE
Ensure the page width is capped at viewport width

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
+html {
+	max-width: 100vw;
+	overflow-x: hidden;
+}
 body {
 	display: -webkit-box;
 	display: -ms-flexbox;


### PR DESCRIPTION
Even though there are no elements "breaking out" of the expected boxes of the DOM, Firefox adds a horizontal scrollbar for some resolutions. I have tried to find out why this happens by deleting all content until the issue disappears and I cannot really explain why the browser behaves the way it does. This PR is somewhat of a forced fix as it ensures the page is never wider than the user's viewport width and cuts off any content that "leaves the page" (which is nothing because that should not happen).