### PR TITLE
Change site id for tracking in matomo

### DIFF
--- a/tracking.js
+++ b/tracking.js
@@ -8,7 +8,7 @@ const trackingData = {
 	},
 	FundraisingTracker: {
 		url: '//tracking.wikimedia.de/',
-		siteID: 3
+		siteID: 1
 	}
 };
 


### PR DESCRIPTION
For the backend to work correctly, we need to track the banner impressions like they come from spenden.wikimedia.de (site id 1) instead of the more correct wikipedia.de (site id 3). See https://phabricator.wikimedia.org/T228398#5462981 for context and discussion.