### PR TITLE
Update docker-compose.yml and PHP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '3'
-
 services:
   app:
-    image: php:5.6-alpine
+    image: php:8.2-alpine
     volumes:
       - ./:/code
     working_dir: /code


### PR DESCRIPTION
Require PHP 8.2 to match PHP on our new server

Remove deprecated version property
